### PR TITLE
Support running multiple services locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ To spin up a stack of all but one service so you can run a development version o
 npm start -- --local <service-name>
 ```
 
-_Note: you will need to make sure that the local service is configured to use the docker versions of everything else_
+_Note: you will need to make sure that the local service is configured to use the docker versions of everything else - i.e. hosts and ports are set to match those in the docker compose config._
+
+To run multiple services locally, simply pass multiple `--local` flags:
+
+```
+npm start -- --local <service-name> --local <another-service-name>
+```
 
 ### Seeding data
 

--- a/bin/conductor
+++ b/bin/conductor
@@ -12,4 +12,6 @@ args.env = args.env || '.env';
 args.out = args.out || 'docker-compose.yml';
 args.detach = args.detach || args.d;
 
+args.local = [].concat(args.local).filter(Boolean);
+
 conductor(config, args);

--- a/lib/conductor.js
+++ b/lib/conductor.js
@@ -14,7 +14,7 @@ module.exports = (settings, args) => {
   const normalise = service => {
     console.log(`Configuring service: ${service.name}`);
     service.links = service.links || [];
-    if (args.local === service.name) {
+    if (args.local.includes(service.name)) {
       service.local = true;
       service.host = 'host.docker.internal';
     } else {
@@ -54,7 +54,7 @@ module.exports = (settings, args) => {
   };
 
   const getLinks = (service, i, all) => {
-    service.links = service.links.filter(link => link !== args.local);
+    service.links = service.links.filter(link => !args.local.includes(link));
     return { ...service };
   };
 


### PR DESCRIPTION
You can run with multiple services defined as `--local` and all of them will be removed from the docker stack.

e.g. `npm start -- --local asl --local asl-public-api`