### PR TITLE
s/bash/sh in asl-schema command

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -112,7 +112,7 @@
     },
     {
       "name": "asl-schema",
-      "run": "bash -c 'npm run migrate'",
+      "run": "sh -c 'npm run migrate'",
       "links": [
         "postgres"
       ],


### PR DESCRIPTION
The image uses alpine linux now, which doesn't ship with `bash`. Change it to use `sh`.