### PR TITLE
Run detached process by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ By default the config will be read from `./conductor.json` and a `docker-compose
 npm run conductor -- alternative-input.json --out docker-compose-alt.yml
 ```
 
-To run `docker-compose` detached:
+`docker-compose` will run detached by default, to run undetached:
 
 ```
-npm run conductor -- --detach
+npm run conductor -- --no-detach
 ```

--- a/bin/conductor
+++ b/bin/conductor
@@ -10,7 +10,6 @@ const config = require(path.resolve(process.cwd(), file));
 
 args.env = args.env || '.env';
 args.out = args.out || 'docker-compose.yml';
-args.detach = args.detach || args.d;
 
 args.local = [].concat(args.local).filter(Boolean);
 

--- a/lib/conductor.js
+++ b/lib/conductor.js
@@ -75,7 +75,7 @@ module.exports = (settings, args) => {
     })
     .then(file => {
       const opts = ['-f', file, 'up'];
-      if (args.detach) {
+      if (args.detach !== false) {
         opts.push('-d');
       }
       spawn('docker-compose', opts, { stdio: 'inherit' });


### PR DESCRIPTION
Most of the time running docker-compose in headless mode is preferable, so make that the default.