### PR TITLE
Remove orphan images by default

### DIFF
--- a/lib/conductor.js
+++ b/lib/conductor.js
@@ -74,7 +74,7 @@ module.exports = (settings, args) => {
       return output;
     })
     .then(file => {
-      const opts = ['-f', file, 'up'];
+      const opts = ['-f', file, 'up', '--remove-orphans'];
       if (args.detach !== false) {
         opts.push('-d');
       }


### PR DESCRIPTION
This means that running with a local service will automatically stop any existing instance of that service in docker-compose.