### PR TITLE
Add --no-pull flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 docker-compose.yml
+.images.json

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ npm start -- --local <service-name> --local <another-service-name>
 
 To populate the postgres database with dummy development data run `npm run seed`. You should only need to do this once.
 
+## Offline-ish access
+
+Add a `--no-pull` flag to use the last-used image version and _hopefully_ prevent pulling new images from the internet.
+
 ## Troubleshooting
 
 This is _very_ hacky, and occasionally things fail because they started up in a funny order.

--- a/bin/conductor
+++ b/bin/conductor
@@ -10,6 +10,7 @@ const config = require(path.resolve(process.cwd(), file));
 
 args.env = args.env || '.env';
 args.out = args.out || 'docker-compose.yml';
+args.pull = args.pull !== false;
 
 args.local = [].concat(args.local).filter(Boolean);
 

--- a/lib/conductor.js
+++ b/lib/conductor.js
@@ -6,6 +6,7 @@ const fetch = require('r2');
 const dotenv = require('dotenv');
 const mustache = require('mustache');
 const { keyBy } = require('lodash');
+const ImageCache = require('./image-cache');
 
 mustache.escape = text => text;
 
@@ -28,11 +29,19 @@ module.exports = (settings, args) => {
   };
 
   const getImage = service => {
-    if (!service.image && !service.build) {
+    if (args.pull && !service.image && !service.build) {
       return fetch(`https://quay.io/api/v1/repository/ukhomeofficedigital/${service.name}/tag`).json
         .then(response => Object.values(response.tags))
         .then(tags => tags[0])
         .then(tag => tag && `quay.io/ukhomeofficedigital/${service.name}:${tag.name}`)
+        .then(image => {
+          return ImageCache.write(service.name, image)
+            .then(() => {
+              return { ...service, image };
+            });
+        });
+    } else if (!service.image && !service.build) {
+      return ImageCache.read(service.name)
         .then(image => {
           return { ...service, image };
         });

--- a/lib/image-cache.js
+++ b/lib/image-cache.js
@@ -1,0 +1,40 @@
+const path = require('path');
+const fs = require('fs');
+
+const file = path.resolve(process.cwd(), '.images.json');
+
+const readFile = () => {
+  return Promise.resolve()
+    .then(() => fs.readFileSync(file))
+    .then(json => JSON.parse(json))
+    .catch(e => ({}));
+};
+
+const writeFile = list => {
+  return Promise.resolve()
+    .then(() => JSON.stringify(list, null, '  '))
+    .then(json => fs.writeFileSync(file, json));
+};
+
+module.exports = {
+
+  read: service => {
+    return Promise.resolve()
+      .then(() => readFile())
+      .then(json => json[service])
+      .then(image => {
+        if (!image) {
+          throw new Error(`No cached image available for service: ${service}`);
+        }
+        return image;
+      });
+  },
+
+  write: (service, image) => {
+    return Promise.resolve()
+      .then(() => readFile())
+      .then(json => ({ ...json, [service]: image }))
+      .then(json => writeFile(json));
+  }
+
+};


### PR DESCRIPTION
This uses whatever the last image version you used so _should_ prevent Docker trying to download new images.

For the benefit of Trainphil and Trainjoe.