### PR TITLE
Reset search index on seed

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "migrate": "docker-compose run asl-schema sh -c 'npm run migrate' && docker-compose exec asl-workflow npm run migrate",
     "seed": "docker-compose run asl-schema sh -c 'npm run seed' && docker-compose exec asl-workflow npm run seed",
     "preseed": "npm run migrate",
-    "build-search-index": "docker-compose run asl-search sh -c 'npm run indexer'",
+    "build-search-index": "docker-compose run asl-search sh -c 'npm run indexer -- --reset'",
     "postseed": "npm run build-search-index",
     "test": "eslint ."
   },


### PR DESCRIPTION
The indexer needs the --reset flag in order to clean out any old records that might be present in the index after a seed run.