### PR TITLE
Update localstack and aws-cli

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -323,8 +323,8 @@
     },
     {
       "name": "sqs",
-      "image": "localstack/localstack:0.11.2",
-      "port": 4576,
+      "image": "localstack/localstack:0.13",
+      "port": 4566,
       "env": {
         "SERVICES": "sqs",
         "DEFAULT_REGION": "{{env.SQS_REGION}}"
@@ -332,11 +332,11 @@
     },
     {
       "name": "aws-cli",
-      "image": "mesosphere/aws-cli",
+      "image": "amazon/aws-cli:latest",
       "links": [
         "sqs"
       ],
-      "run": "--endpoint-url=http://sqs:4576 sqs create-queue --queue-name=asl-dev --region=eu-west-1 --no-sign-request --no-verify-ssl"
+      "run": "--endpoint-url=http://sqs:4566 sqs create-queue --queue-name=asl-dev --region=eu-west-1 --no-sign-request --no-verify-ssl"
     },
     {
       "name": "postgres",

--- a/conductor.json
+++ b/conductor.json
@@ -324,8 +324,9 @@
     {
       "name": "sqs",
       "image": "localstack/localstack:0.13",
-      "port": 4566,
+      "port": 4576,
       "env": {
+        "EDGE_PORT": 4576,
         "SERVICES": "sqs",
         "DEFAULT_REGION": "{{env.SQS_REGION}}"
       }
@@ -336,7 +337,7 @@
       "links": [
         "sqs"
       ],
-      "run": "--endpoint-url=http://sqs:4566 sqs create-queue --queue-name=asl-dev --region=eu-west-1 --no-sign-request --no-verify-ssl"
+      "run": "--endpoint-url=http://sqs:4576 sqs create-queue --queue-name=asl-dev --region=eu-west-1 --no-sign-request --no-verify-ssl"
     },
     {
       "name": "postgres",

--- a/conductor.json
+++ b/conductor.json
@@ -333,10 +333,14 @@
     {
       "name": "aws-cli",
       "image": "amazon/aws-cli:2.4.6",
+      "depends_on": [
+        "sqs"
+      ],
       "links": [
         "sqs"
       ],
-      "run": "--endpoint-url=http://sqs:4566 sqs create-queue --queue-name=asl-dev --region=eu-west-1 --no-sign-request --no-verify-ssl"
+      "run": "--endpoint-url=http://sqs:4566 sqs create-queue --queue-name=asl-dev --region=eu-west-1 --no-sign-request --no-verify-ssl",
+      "restart": "on-failure"
     },
     {
       "name": "postgres",

--- a/conductor.json
+++ b/conductor.json
@@ -87,7 +87,7 @@
         "SQS_REGION": "{{env.SQS_REGION}}",
         "SQS_ACCESS_KEY": "{{env.SQS_ACCESS_KEY}}",
         "SQS_SECRET": "{{env.SQS_SECRET}}",
-        "SQS_URL": "http://{{services.sqs.host}}:{{services.sqs.port}}/queue/asl-dev",
+        "SQS_URL": "http://{{services.sqs.host}}:{{services.sqs.port}}/000000000000/asl-dev",
         "S3_REGION": "{{env.S3_REGION}}",
         "S3_ACCESS_KEY": "{{env.S3_ACCESS_KEY}}",
         "S3_SECRET": "{{env.S3_SECRET}}",
@@ -125,7 +125,7 @@
         "SQS_REGION": "{{env.SQS_REGION}}",
         "SQS_ACCESS_KEY": "{{env.SQS_ACCESS_KEY}}",
         "SQS_SECRET": "{{env.SQS_SECRET}}",
-        "SQS_URL": "http://{{services.sqs.host}}:{{services.sqs.port}}/queue/asl-dev",
+        "SQS_URL": "http://{{services.sqs.host}}:{{services.sqs.port}}/000000000000/asl-dev",
         "S3_REGION": "{{env.S3_REGION}}",
         "S3_ACCESS_KEY": "{{env.S3_ACCESS_KEY}}",
         "S3_SECRET": "{{env.S3_SECRET}}",
@@ -324,20 +324,19 @@
     {
       "name": "sqs",
       "image": "localstack/localstack:0.13",
-      "port": 4576,
+      "port": 4566,
       "env": {
-        "EDGE_PORT": 4576,
         "SERVICES": "sqs",
-        "DEFAULT_REGION": "{{env.SQS_REGION}}"
+        "SQS_PROVIDER": "elasticmq"
       }
     },
     {
       "name": "aws-cli",
-      "image": "amazon/aws-cli:latest",
+      "image": "amazon/aws-cli:2.4.6",
       "links": [
         "sqs"
       ],
-      "run": "--endpoint-url=http://sqs:4576 sqs create-queue --queue-name=asl-dev --region=eu-west-1 --no-sign-request --no-verify-ssl"
+      "run": "--endpoint-url=http://sqs:4566 sqs create-queue --queue-name=asl-dev --region=eu-west-1 --no-sign-request --no-verify-ssl"
     },
     {
       "name": "postgres",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   },
   "scripts": {
     "start": "bin/conductor",
-    "poststart": "docker-compose restart aws-cli",
     "conductor": "bin/conductor",
     "migrate": "docker-compose run --rm asl-schema sh -c 'npm run migrate' && docker-compose run --rm asl-workflow npm run migrate",
     "seed": "docker-compose run --rm asl-schema sh -c 'npm run seed' && docker-compose run --rm asl-workflow npm run seed",

--- a/template/docker-compose.tpl.yml
+++ b/template/docker-compose.tpl.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.8'
 services:
 {{#services}}
   {{name}}:
@@ -27,4 +27,13 @@ services:
     {{#run}}
     command: "{{run}}"
     {{/run}}
+    {{#depends_on.length}}
+    depends_on:
+    {{#depends_on}}
+      - {{.}}
+    {{/depends_on}}
+    {{/depends_on.length}}
+    {{#restart}}
+    restart: {{restart}}
+    {{/restart}}
 {{/services}}


### PR DESCRIPTION
## Why?
SQS seems to keep falling over for me on M1 Mac. Not sure exactly why but we're using quite an old localstack.

## localstack
 - The newer versions of localstack have native arm64 support
 - The default port config now seems to be 4566 (configurable with `EDGE_PORT`)
 - The default SQS provider is now `moto` but has issues so using previous provider `elasticmq` see notes
 - There is now a `/health` endpoint we could ping to see if services have started (e.g. SQS) https://github.com/localstack/localstack#service-health-checks

### Notes
The default port has changed - we could config it back to the same port as before (4576) but all the docs use 4566 and some tooling expects 4566 so in the long run I think it's probably just easier to update our `.env` with the new port.

localstack sqs now includes the account id in the path, so by default you end up with a URL like http://localhost:4566/000000000000/asl-dev

You can configure the value with the env var `TEST_AWS_ACCOUNT_ID` and set it to `queue` for a url like http://localhost:4566/queue/asl-dev when using the newer `moto` provider, but the previous provider `elasticmq` seems to ignore it.

However, the `moto` provider seems to return invalid uuids as the `MessageId` and our app throws validation errors if a `MessageId` is not uuid v4, so we can't use it without modifying our uuid validation. Amazon don't seem to actually guarantee that MessageIds will be UUID v4 so this may be something we need to look at:
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html#message-id

## aws-cli
 - Switch to official amazon/aws-cli image which has native arm64 support
 - mesosphere version hasn't been updated in about 4 years
 - Only supports AWS CLI v2 but seems to be a drop-in replacement for our usage

## TLDR;
 - You will need to update your `.env` file with `SQS_URL=http://localhost:4566/000000000000/asl-dev`

