### PR TITLE
Pin version of html-pdf-converter

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -223,6 +223,7 @@
     },
     {
       "name": "html-pdf-converter",
+      "image": "quay.io/ukhomeofficedigital/html-pdf-converter:v2.4.3",
       "network": "asl",
       "env": {
         "BODY_SIZE_LIMIT": "5mb"


### PR DESCRIPTION
The html-pdf-converter drone pipeline is set to publish an image for the commit sha for PRs, so broken PRs can cause problems when using the latest image